### PR TITLE
FIX: added maven central repo for gradle builds

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,9 @@ plugins {
 allprojects {
   apply plugin: 'idea'
 
+  repositories{
+    mavenCentral()
+  }
   task copyCodeStyle(type: Copy) {
     from "ide/idea/codeStyleSettings.xml"
     into ".idea"


### PR DESCRIPTION
Tried to build project, but several dependencies were not found. Found them in Maven central repo, then tried to add Maven central repo into build.gradle, it simply worked.
