### PR TITLE
Fixes issue with composite partition keys not being escaped correctly.

### DIFF
--- a/core/src/main/spark3/org/apache/cassandra/spark/sparksql/CassandraTableProvider.java
+++ b/core/src/main/spark3/org/apache/cassandra/spark/sparksql/CassandraTableProvider.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import org.apache.cassandra.spark.shaded.fourzero.cassandra.db.marshal.AbstractCompositeType;
 import org.apache.commons.lang3.tuple.Pair;
 
 import org.apache.cassandra.spark.data.CqlField;
@@ -209,7 +210,8 @@ class CassandraScanBuilder implements ScanBuilder, Scan, Batch, SupportsPushDown
 
     private PartitionKeyFilter buildFilter(List<String> keys)
     {
-        final String compositeKey = String.join(":", keys);
+        final String compositeKey = keys.stream().map(AbstractCompositeType::escape)
+                .collect(Collectors.joining(":"));
         final Pair<ByteBuffer, BigInteger> filterKey = this.dataLayer.bridge()
                                                                      .getPartitionKey(this.dataLayer.cqlSchema(), this.dataLayer.partitioner(), compositeKey);
         return PartitionKeyFilter.create(filterKey.getLeft(), filterKey.getRight());


### PR DESCRIPTION
`CassandraTableProvider#buildFilter` currently uses `String#join` to combine together the partition key components from the pushed spark filters. If any of the keys contains a ":" they will be incorrectly encoded, which causes issues later in `FourZero#getPartitionKey` when the combined key is processed using `AbstractCompositeType#fromString`.

The key values should be escaped using `AbstractCompositeType#escape` before joining.

I encountered this issue when trying to process a table with a `timestamp` column inside a composite partition key. The ":"'s inside the timestamp caused issues. 

TBD: Is `String#join` the correct method to use? `AbstractCompositeType#getString` looks promising (does the correct escaping, etc), but more complex to use.